### PR TITLE
dory: remove dependency of docker plugin for init command

### DIFF
--- a/cmd/flexvolume-driver/driver.go
+++ b/cmd/flexvolume-driver/driver.go
@@ -79,6 +79,22 @@ func main() {
 	log.Infof("[%d] entry  : Driver=%s Version=%s-%s Socket=%s Overridden=%t", pid, filepath.Base(os.Args[0]), Version, Commit, dockerVolumePluginSocketPath, overridden)
 
 	log.Infof("[%d] request: %s %v", pid, driverCommand, os.Args[2:])
+
+	if driverCommand == flexvol.InitCommand {
+		log.Trace("enable1.6=", enable16)
+		var resp string
+		if enable16 {
+			resp = flexvol.BuildJSONResponse(&flexvol.Response{Status: flexvol.SuccessStatus})
+			log.Infof("[%d] reply  : %s %v: %v", pid, driverCommand, os.Args[2:], resp)
+		} else {
+			capabilities := map[string]bool{"attach": false}
+			resp = flexvol.BuildJSONResponse(&flexvol.Response{Status: flexvol.SuccessStatus, DriverCapabilities: capabilities})
+			log.Infof("[%d] reply  : %s %v: %v", pid, driverCommand, os.Args[2:], resp)
+		}
+		fmt.Println(resp)
+		return
+	}
+
 	dockervolOptions := &dockervol.Options{
 		SocketPath:                   dockerVolumePluginSocketPath,
 		StripK8sFromOptions:          stripK8sFromOptions,

--- a/pkg/flexvol/handler.go
+++ b/pkg/flexvol/handler.go
@@ -23,15 +23,6 @@ import (
 
 // Handle the conversion of flexvol commands and args to docker volume
 func Handle(driverCommand string, enable16 bool, args []string) string {
-	if driverCommand == InitCommand {
-		log.Trace("enable1.6=", enable16)
-		if enable16 {
-			return BuildJSONResponse(&Response{Status: SuccessStatus})
-		}
-		capabilities := map[string]bool{"attach": false}
-		return BuildJSONResponse(&Response{Status: SuccessStatus, DriverCapabilities: capabilities})
-	}
-
 	err := ensureArg(driverCommand, args, 1)
 	if err != nil {
 		return BuildJSONResponse(ErrorResponse(err))


### PR DESCRIPTION
* Problem:
  * During node reboot, or docker plugin restarts, kubelet can be polling
  * dory with init. Due to dependency of docker-plugin for init, we keep failing
  * request as socket not available. This causes kubelet to unnecessariliy enter loop
  * of polling dory, causing delay in reboot, and sometimes node getting into not ready.
* Implementation:
  * Remove dependency of docker socket to be available for "init" call. During mount/unmount
  * calls if docker plugin is not ready, then we fail requests anyway and they will be retried.
  * With this at-least kubelet will not bother dory during node restarts or docker-plugin restarts.
* Testing: Tested with dory init calls and killing docker-plugin.
* Review: gcostea, rkumar
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>